### PR TITLE
Define response type for FileDownload to prevent corrupted files 

### DIFF
--- a/src/BunnyClient.ts
+++ b/src/BunnyClient.ts
@@ -36,6 +36,7 @@ class _Client {
   static FileDownload = (k: string, url: string) => axios.get(url, {
     baseURL: "https://storage.bunnycdn.com/",
     timeout: 2000000000,
+    responseType: 'arraybuffer',
     maxContentLength: Number.POSITIVE_INFINITY,
     headers: {
       'AccessKey': Config.getApiKey(k, "storages"),


### PR DESCRIPTION
After downloading image files, I receive a message on my M1 Mac (14.6.1) that the files are corrupted. 

This PR fixes this error. The image files can be opened without any problems.